### PR TITLE
Handle last_state issue and also reward based utility computation

### DIFF
--- a/iter8_analytics/api/analytics/detailedmetrics.py
+++ b/iter8_analytics/api/analytics/detailedmetrics.py
@@ -27,6 +27,16 @@ class GaussianBelief(Belief):
 
     def sample_posterior(self):
         self.sample = np.random.normal(loc = self.mean, scale = self.stddev, size = self.sample_size)
+        return self.sample
+
+class ConstantBelief(Belief):
+    def __init__(self, value):
+        self.value = value
+        self.status = StatusEnum.all_ok
+
+    def sample_posterior(self):
+        self.sample = np.full((self.sample_size, ), np.float(self.value))
+        return self.sample
 
 class DetailedMetric():
     """Base class for a detailed metric.
@@ -61,7 +71,7 @@ class DetailedMetric():
 class DetailedCounterMetric(DetailedMetric):
     def __init__(self, metric_spec, detailed_version):
         super().__init__(metric_spec, detailed_version)
-        self.aggregated_metric = AggregatedRatioDataPoint(status = StatusEnum.uninitialized_value)
+        self.aggregated_metric = AggregatedCounterDataPoint(status = StatusEnum.uninitialized_value)
 
 class DetailedRatioMetric(DetailedMetric):
     def __init__(self, metric_spec, detailed_version):
@@ -82,3 +92,5 @@ class DetailedRatioMetric(DetailedMetric):
                         width = mm.maximum - mm.minimum
                         if width > 0:
                             self.belief = GaussianBelief(mean = self.aggregated_metric.value, variance=width / (1 + denominator_value))
+                        else:
+                            self.belief = ConstantBelief(value = mm.maximum)

--- a/iter8_analytics/api/analytics/detailedversion.py
+++ b/iter8_analytics/api/analytics/detailedversion.py
@@ -68,7 +68,6 @@ class DetailedVersion():
         # self.beliefs =  {
         #     metric_id: Belief(status = StatusEnum.uninitialized_belief) for metric_id in self.experiment.ratio_metric_specs
         # }
-        self.utility_sample = Belief(status = StatusEnum.uninitialized_belief)
 
         if experiment.eip.last_state:
             if experiment.eip.last_state.aggregated_counter_metrics:
@@ -147,11 +146,12 @@ class DetailedVersion():
                 rm.belief.sample_posterior()
 
     def create_utility_samples(self):
-        """Create utility samples used for assessment and traffic routing. Updates self.utility _sample object.
+        """Create utility samples used for winner assessment and traffic routing
         """
         ## Initialize reward and utility sample
         reward_sample = np.ones(Belief.sample_size) * self.pseudo_reward
-        self.utilities = np.ones(Belief.sample_size)
+        if not self.aggregate_counter_metrics[ITER8_REQUEST_COUNT].value:
+            self.utility_sample = np.ones(Belief.sample_size) * float("inf")
 
         # for criterion in self.experiment.eip.criteria:
         #     if criterion.metric_id in self.metrics["counter_metrics"]:

--- a/iter8_analytics/api/analytics/endpoints/examples.py
+++ b/iter8_analytics/api/analytics/endpoints/examples.py
@@ -12,7 +12,7 @@ eip_example = {
         },
         {
             "id": "iter8_total_latency",
-            "query_template": "sum(increase(istio_request_duration_seconds_sum{reporter='source'}[$interval])) by ($version_labels)"
+            "query_template": "sum(increase(istio_request_duration_milliseconds_sum{reporter='source'}[$interval])) by ($version_labels)"
         },
         {
             "id": "iter8_error_count",
@@ -174,7 +174,7 @@ reviews_example = {
       },
       {
         "id": "iter8_total_latency",
-        "query_template": "sum(increase(istio_request_duration_seconds_sum{reporter='source'}[$interval])) by ($version_labels)"
+        "query_template": "sum(increase(istio_request_duration_milliseconds_sum{reporter='source'}[$interval])) by ($version_labels)"
       },
       {
         "id": "iter8_error_count",
@@ -207,7 +207,7 @@ reviews_example = {
       "is_reward": False,
       "threshold": {
         "type": "absolute",
-        "value": 25
+        "value": 500
       }
     }
   ],
@@ -368,7 +368,7 @@ reviews_example_with_last_state = {
       },
       {
         "id": "iter8_total_latency",
-        "query_template": "sum(increase(istio_request_duration_seconds_sum{reporter='source'}[$interval])) by ($version_labels)"
+        "query_template": "sum(increase(istio_request_duration_milliseconds_sum{reporter='source'}[$interval])) by ($version_labels)"
       },
       {
         "id": "iter8_error_count",
@@ -401,7 +401,7 @@ reviews_example_with_last_state = {
       "is_reward": False,
       "threshold": {
         "type": "absolute",
-        "value": 25
+        "value": 500
       }
     }
   ],
@@ -453,7 +453,7 @@ eip_with_invalid_ratio["criteria"].append({
     "is_reward": False,
     "threshold": {
           "type": "absolute",
-          "value": 25
+          "value": 500
     }
 })
 
@@ -464,7 +464,7 @@ eip_with_unknown_metric_in_criterion["criteria"].append({
     "is_reward": False,
     "threshold": {
           "type": "absolute",
-          "value": 25
+          "value": 500
     }
 })
 

--- a/iter8_analytics/api/analytics/endpoints/examples.py
+++ b/iter8_analytics/api/analytics/endpoints/examples.py
@@ -472,4 +472,3 @@ reviews_example_without_request_count = copy.deepcopy(reviews_example)
 del reviews_example_without_request_count["criteria"][1]
 del reviews_example_without_request_count["metric_specs"]["counter_metrics"][0]
 del reviews_example_without_request_count["metric_specs"]["ratio_metrics"][0]
-

--- a/iter8_analytics/api/analytics/experiment.py
+++ b/iter8_analytics/api/analytics/experiment.py
@@ -233,9 +233,12 @@ class Experiment():
         Create traffic split using the top-k PBR algorithm
         """
         self.traffic_split[k] = {}
+
         # get the fractional split
-        rank_df = self.utilities.rank(axis = 1, method = 'min')
-        low_rank = rank_df <= 1
+        rank_df = self.utilities.rank(axis = 1, method = 'min', ascending = False)
+
+        low_rank = rank_df <= k
+
         fractional_split = low_rank.sum() / low_rank.sum().sum()
         # round the fractional split so that it sums up to 100
         integral_split_gen = gen_round(fractional_split * 100, 100)

--- a/iter8_analytics/api/analytics/experiment.py
+++ b/iter8_analytics/api/analytics/experiment.py
@@ -57,7 +57,8 @@ class Experiment():
         if ITER8_REQUEST_COUNT in all_counter_metric_specs:
             self.counter_metric_specs[ITER8_REQUEST_COUNT] = all_counter_metric_specs[ITER8_REQUEST_COUNT]
         else:
-            logger.warning("iter8_request_count metric is missing in metric specs")
+            logger.error("iter8_request_count metric is missing in metric specs")
+            raise HTTPException(status_code=422, detail = f"{ITER8_REQUEST_COUNT} is a mandatory counter metric which is missing from the list of metric specs")
         self.ratio_metric_specs = {}
 
         for cri in self.eip.criteria:
@@ -179,7 +180,7 @@ class Experiment():
             metric_id: [] for metric_id in self.ratio_metric_specs
         }
 
-        if self.eip.last_state:
+        if self.eip.last_state and self.eip.last_state.ratio_max_mins:
             for metric_id in self.ratio_metric_specs:
                 a = self.eip.last_state.ratio_max_mins[metric_id].minimum
                 b = self.eip.last_state.ratio_max_mins[metric_id].maximum
@@ -252,11 +253,7 @@ class Experiment():
         baseline_assessment = None
         candidate_assessments = []
         for version in self.detailed_versions.values():
-            request_count = None
-            if ITER8_REQUEST_COUNT in self.counter_metric_specs:
-                request_count = version.metrics["counter_metrics"][ITER8_REQUEST_COUNT].aggregated_metric.value
-            else:
-                logger.warning("iter8_request_count metric is missing in metric specs")
+            request_count = version.metrics["counter_metrics"][ITER8_REQUEST_COUNT].aggregated_metric.value
 
             if version.is_baseline:
                 baseline_assessment = VersionAssessment(

--- a/iter8_analytics/api/analytics/metrics.py
+++ b/iter8_analytics/api/analytics/metrics.py
@@ -9,6 +9,7 @@ import logging
 import requests
 from string import Template
 import math
+from pprint import pformat
 
 # external module dependencies
 from pydantic import BaseModel, Field
@@ -346,7 +347,7 @@ class PrometheusRatioMetricQuery(PrometheusMetricQuery):
             value = None,
             timestamp = ts,
             status = StatusEnum.nan_value
-        ) if math.isnan(result_float) else RatioDataPoint(
+        ) if math.isnan(result_float) or math.isinf(result_float) else RatioDataPoint(
             value = result_float,
             timestamp = ts
         )

--- a/iter8_analytics/fastapi_app.py
+++ b/iter8_analytics/fastapi_app.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import sys
+from pprint import pformat
 
 # external dependencies
 from fastapi import FastAPI, Body
@@ -29,7 +30,10 @@ def provide_assessment_for_this_experiment_iteration(eip: ExperimentIterationPar
     \f
     :body eip: ExperimentIterationParameters
     """
-    return experiment.Experiment(eip).run()
+    run_result = experiment.Experiment(eip).run()
+
+    logger = logging.getLogger('iter8_analytics')
+    return run_result
 
 
 @app.get("/health_check")

--- a/tests/api/analytics/endpoints/experiment_test.py
+++ b/tests/api/analytics/endpoints/experiment_test.py
@@ -37,6 +37,14 @@ class TestExperiment:
         eip_with_ratio_max_mins = ExperimentIterationParameters(** reviews_example_with_ratio_max_mins)
         exp_with_partial_last_state = Experiment(eip_with_ratio_max_mins)
 
+    def test_missing_iter8_request_count(self):
+        try:
+            eip = ExperimentIterationParameters(** reviews_example_without_request_count)
+            exp = Experiment(eip)
+        except HTTPException as he:
+            pass
+
+
     def test_invalid_ratio_metric(self):
         try:
             eip = ExperimentIterationParameters(** eip_with_invalid_ratio)
@@ -70,18 +78,6 @@ class TestExperiment:
             eip = ExperimentIterationParameters(** reviews_example_with_ratio_max_mins)
             exp = Experiment(eip)
             exp.run()
-
-    def test_missing_iter8_request_count(self):
-        with requests_mock.mock(real_http=True) as m:
-            m.get(metrics_endpoint, json=json.load(open("tests/data/prometheus_sample_response.json")))
-
-            eip = ExperimentIterationParameters(** reviews_example_without_request_count)
-            exp = Experiment(eip)
-            resp = exp.run()
-
-            assert resp.baseline_assessment.request_count is None
-            for assessment in resp.candidate_assessments:
-                assert assessment.request_count is None
 
 class TestDetailedVersion:
     def test_detailed_version(self):

--- a/tests/fastapi_app_test.py
+++ b/tests/fastapi_app_test.py
@@ -1,6 +1,7 @@
 import requests_mock
 import logging
 import json
+import copy
 
 from fastapi.testclient import TestClient
 
@@ -30,9 +31,22 @@ class TestUnifiedAnalyticsAPI:
             # fastapi post data
             eip = ExperimentIterationParameters(** eip_example)
 
-            logger.info("\n\n\n")
-            logger.info('===TESTING FASTAPI ENDPOINT')
-            logger.info("Test request with some required parameters")
+            # Call the FastAPI endpoint via the test client
+            resp = test_client.post(endpoint, json = eip_example)
+            it8_ar_example = Iter8AssessmentAndRecommendation(** resp.json())
+            assert resp.status_code == 200
+
+    def test_fastapi_with_empty_last_state(self):
+        # fastapi endpoint
+        with requests_mock.mock(real_http=True) as m:
+            m.get(metrics_endpoint, json=json.load(open("tests/data/prometheus_sample_response.json")))
+
+            endpoint = "/assessment"
+
+            # fastapi post data
+            eg = copy.deepcopy(eip_example)
+            eg['last_state'] = {}
+            eip = ExperimentIterationParameters(** eg)
 
             # Call the FastAPI endpoint via the test client
             resp = test_client.post(endpoint, json = eip_example)


### PR DESCRIPTION
Traffic splits should now take rewards or pseudo reward into consideration.

Pseudo rewards are used for canary releases. Real reward metrics are used when there is a reward criterion.