### PR TITLE
interval = 0 issue during first iteration + changes to winner assessment

### DIFF
--- a/iter8_analytics/api/analytics/detailedmetric.py
+++ b/iter8_analytics/api/analytics/detailedmetric.py
@@ -101,7 +101,7 @@ class DetailedRatioMetric(DetailedMetric):
                     if mm.maximum is not None and mm.minimum is not None:
                         width = mm.maximum - mm.minimum
                         if width > 0:
-                            self.belief = GaussianBelief(mean = self.aggregated_metric.value, variance=width / (1 + denominator_value))
+                            self.belief = GaussianBelief(mean = self.aggregated_metric.value, variance=width*AdvancedParameters.variance_boost_factor / (1 + denominator_value))
                             logger.debug(f"Gaussian belief: {self.belief}")
                         else:
                             self.belief = ConstantBelief(value = mm.maximum)

--- a/iter8_analytics/api/analytics/detailedversion.py
+++ b/iter8_analytics/api/analytics/detailedversion.py
@@ -107,6 +107,7 @@ class DetailedVersion():
         """
         for rm in self.metrics["ratio_metrics"].values():
             rm.update_belief()
+            logger.info(f"Updated belief: {vars(rm.belief)}")
 
     def create_ratio_metric_samples(self):
         """Create ratio metric samples used for assessment and traffic routing

--- a/iter8_analytics/api/analytics/experiment.py
+++ b/iter8_analytics/api/analytics/experiment.py
@@ -160,6 +160,7 @@ class Experiment():
 
         for detailed_version in self.detailed_versions.values():
             # beliefs are needed for creating posterior samples
+            logger.info(f"Updating beliefs for {detailed_version.id}")
             detailed_version.update_beliefs()
             # posterior samples for ratio metrics are needed to create reward and criterion masks
             detailed_version.create_ratio_metric_samples()
@@ -171,6 +172,7 @@ class Experiment():
         # utility samples are needed for winner assessment and traffic recommendations
         self.create_utility_samples()
         self.create_winner_assessments()
+        self.add_baseline_bias()
         self.create_traffic_recommendations()
         return self.assemble_assessment_and_recommendations()
 
@@ -187,9 +189,10 @@ class Experiment():
 
         # multiple effective rewards with criteria masks
         self.utilities = self.effective_rewards * self.criteria_mask
+
+    def add_baseline_bias(self):
         # bias term to ensure baseline is picked when all versions have zero utilities
         self.utilities[self.detailed_baseline_version.id] += 1.0e-10
-
 
     def get_aggregated_counter_metrics(self):
         """Get aggregated counter metrics for this detailed version
@@ -351,22 +354,24 @@ class Experiment():
         }
 
         # get winner assessments
+
         wvf = False
-        wa = WinnerAssessment(
-                winning_version_found = wvf
-            )
-        current_winner = self.win_probababilities.index[np.argmax(self.win_probababilities)]
-        current_winner_probability = self.win_probababilities[current_winner]
-        if current_winner_probability > AdvancedParameters.min_posterior_probability_for_winner:
+
+        current_best_version = self.win_probababilities.index[np.argmax(self.win_probababilities)]
+        probability_of_winning_for_best_version = self.win_probababilities[current_best_version]
+
+        if probability_of_winning_for_best_version > AdvancedParameters.min_posterior_probability_for_winner:
             wvf = True
-            wa = WinnerAssessment(
-                winning_version_found = wvf,
-                current_winner = current_winner,
-                winning_probability = current_winner_probability
-            )
-        logger.debug("Winner assessment")
-        logger.debug(self.win_probababilities)
-        logger.debug(f"{wvf, current_winner, current_winner_probability}")
+
+        wa = WinnerAssessment(
+            winning_version_found=wvf,
+            current_best_version=current_best_version,
+            probability_of_winning_for_best_version=probability_of_winning_for_best_version
+        )
+
+        logger.info("Winner assessment")
+        logger.info(self.win_probababilities)
+        logger.info(f"{(wvf, current_best_version, probability_of_winning_for_best_version)}")
 
         # get final assessment and response
         it8ar = Iter8AssessmentAndRecommendation(** {

--- a/iter8_analytics/api/analytics/metrics.py
+++ b/iter8_analytics/api/analytics/metrics.py
@@ -197,6 +197,16 @@ class PrometheusMetricQuery():
             query_result (Dict[str, Dict[str, DataPoint]]]): Post processed query result
         """
         interval = int((current_time - self.query_spec.start_time).total_seconds())
+        if interval < 20.0: # less than twenty seconds has elapsed since start of the experiment
+            logger.info("Less than 20 seconds have elapsed since the start of the experiment")
+            return self.post_process({
+                "status": "success", 
+                "data": {
+                    "resultType": "vector",
+                    "result": []
+                }
+            }, current_time)
+
         kwargs = {
             "interval": f"{interval}s",
             "version_labels": ",".join(self.query_spec.version_label_keys) # also hard coded

--- a/iter8_analytics/api/analytics/types.py
+++ b/iter8_analytics/api/analytics/types.py
@@ -207,7 +207,7 @@ class VersionAssessment(BaseModel): # assessment per version
     # baseline: bool = Field(False, description = "Is this the baseline?")
     request_count: int = Field(None, ge = 0, description = "Number of requests sent to this version until now")
     criterion_assessments: List[CriterionAssessment] = Field(..., description="Metric assessments for this version")
-    win_probability: float = Field(..., description = "Probability that this version is the winner. This is currently computed based on Bayesian estimation")
+    win_probability: float = Field(..., description = "Posterior probability of this version. This is currently computed based on Bayesian estimation")
 
 class CandidateVersionAssessment(VersionAssessment): # assessment per candidate
     rollback: bool = Field(False, description = "Rollback this version. Currently candidates can be rolled back if they violate criteria for which rollback_on_violation is True")

--- a/iter8_analytics/api/analytics/types.py
+++ b/iter8_analytics/api/analytics/types.py
@@ -213,9 +213,9 @@ class CandidateVersionAssessment(VersionAssessment): # assessment per candidate
     rollback: bool = Field(False, description = "Rollback this version. Currently candidates can be rolled back if they violate criteria for which rollback_on_violation is True")
  
 class WinnerAssessment(BaseModel):
-    winning_version_found: bool = Field(False, description = "Indicates whether or not a clear winner has emerged. This is currently computed based on Bayesian estimation and uses posterior_probability_for_winner from the iteration parameters")
-    current_winner: str = Field(None, description = "ID of the current winner with the maximum probability of winning. This is currently computed based on Bayesian estimation")
-    winning_probability: float = Field(None, description = "Posterior probability of the version declared as the current winner. This is None if winner is None. This is currently computed based on Bayesian estimation")
+    winning_version_found: bool = Field(..., description = "Indicates whether or not a clear winner has emerged. This is currently computed based on Bayesian estimation and uses posterior_probability_for_winner from the iteration parameters")
+    current_best_version: str = Field(..., description = "ID of the current best version with the maximum probability of winning. This is currently computed based on Bayesian estimation")
+    probability_of_winning_for_best_version: float = Field(..., description = "Posterior probability of the current best version. This is currently computed based on Bayesian estimation")
    ## coming soon
     # safe_to_rollforward: bool = Field(False, description = "True if it is now safe to terminate the experiment early and rollforward to the winner")
 
@@ -253,3 +253,4 @@ class AdvancedParameters:
     exploration_traffic_percentage = 5.0 # 5% of traffic always used for exploration
     posterior_probability_for_credible_intervals = 0.95
     min_posterior_probability_for_winner = 0.99 # no winner until iter8 is 99% confident
+    variance_boost_factor = 100.0 # a higher value of this factor encourages greater exploration


### PR DESCRIPTION
1. If you have an experiment starttime which is same as the current time (i.e., interval = 0 in prometheus queries), the analytics service will now work -- and not report an error as it did before. This addresses @kalantar and @kimikowang's blockers.

2. I made changes to the way win probability is computed. The idea is to steer the win probabilities towards 0 or 1 gradually as more data points arrive, instead of aggressively, as the analytics service was doing before.

@fabolive FYI. 1) addresses the controller e2e-tests issue with interval = 0.