### PR TITLE
resolve time sync issues in ratio metrics

### DIFF
--- a/iter8_analytics/api/analytics/detailedmetric.py
+++ b/iter8_analytics/api/analytics/detailedmetric.py
@@ -40,7 +40,7 @@ class GaussianBelief(Belief):
         self.sample = np.random.normal(loc = self.mean, scale = self.stddev, size = self.sample_size)
 
 class BetaBelief(Belief):
-    def __init__(self, alpha = 1.0, beta = 1.0):
+    def __init__(self, alpha = 0.1, beta = 0.1):
         super().__init__(StatusEnum.all_ok)
         self.alpha = alpha
         self.beta = beta
@@ -108,6 +108,7 @@ class DetailedRatioMetric(DetailedMetric):
 
             denominator_id = self.metric_spec.denominator
             denominator_value = self.detailed_version.metrics["counter_metrics"][denominator_id].aggregated_metric.value
+            logger.debug(f"Denominator_id: {denominator_id} Denominator value: {denominator_value}")
             # numerator_id = self.metric_spec.numerator
             # numerator_value = self.detailed_version.metrics["counter_metrics"][numerator_id].aggregated_metric.value
 
@@ -117,7 +118,7 @@ class DetailedRatioMetric(DetailedMetric):
                         logger.warning(f"Value {self.aggregated_metric.value} exceeds 1.0 for ratio metric {self.metric_id} which has zero_to_one set to true.")
                     numerator_value = min(self.aggregated_metric.value, 1.0) * denominator_value
                     diff = denominator_value - numerator_value
-                    self.belief = BetaBelief(alpha=1.0 + numerator_value, beta=1.0 + diff)
+                    self.belief = BetaBelief(alpha = 0.1 + numerator_value, beta = 0.1 + diff)
                     logger.debug(f"Beta belief: {self.belief}")
                     return
                 else:  # Gaussian or constant or undefined

--- a/iter8_analytics/api/analytics/detailedmetric.py
+++ b/iter8_analytics/api/analytics/detailedmetric.py
@@ -114,8 +114,8 @@ class DetailedRatioMetric(DetailedMetric):
             if denominator_value is not None and denominator_value > 0:
                 if self.metric_spec.zero_to_one: # beta belief
                     if self.aggregated_metric.value > 1.0:
-                        raise HTTPException(status_code=422, detail=f"Value {self.aggregated_metric.value} exceeds 1.0 for ratio metric {self.metric_id} which has zero_to_one set to true.")
-                    numerator_value = self.aggregated_metric.value * denominator_value
+                        logger.warning(f"Value {self.aggregated_metric.value} exceeds 1.0 for ratio metric {self.metric_id} which has zero_to_one set to true.")
+                    numerator_value = min(self.aggregated_metric.value, 1.0) * denominator_value
                     diff = denominator_value - numerator_value
                     self.belief = BetaBelief(alpha=1.0 + numerator_value, beta=1.0 + diff)
                     logger.debug(f"Beta belief: {self.belief}")

--- a/iter8_analytics/api/analytics/detailedmetric.py
+++ b/iter8_analytics/api/analytics/detailedmetric.py
@@ -108,30 +108,29 @@ class DetailedRatioMetric(DetailedMetric):
 
             denominator_id = self.metric_spec.denominator
             denominator_value = self.detailed_version.metrics["counter_metrics"][denominator_id].aggregated_metric.value
-            numerator_id = self.metric_spec.numerator
-            numerator_value = self.detailed_version.metrics["counter_metrics"][numerator_id].aggregated_metric.value
+            # numerator_id = self.metric_spec.numerator
+            # numerator_value = self.detailed_version.metrics["counter_metrics"][numerator_id].aggregated_metric.value
 
-            if denominator_value is not None:
-                if denominator_value > 0:
-                    # try to use beta belief first -- most specific
-                    if self.metric_spec.zero_to_one:
-                        if numerator_value is not None:
-                            diff = denominator_value - numerator_value
-                            self.belief = BetaBelief(alpha = 1.0 + numerator_value, beta = 1.0 + diff)
-                            if diff < 0.0:
-                                raise HTTPException(status_code=422, detail = f"Numerator value {numerator_value} is greater than denominator value {denominator_value} for ratio metric {self.metric_id} which has zero_to_one set to true")
-                            logger.debug(f"Beta belief: {self.belief}")
+            if denominator_value is not None and denominator_value > 0:
+                if self.metric_spec.zero_to_one: # beta belief
+                    if self.aggregated_metric.value > 1.0:
+                        raise HTTPException(status_code=422, detail=f"Value {self.aggregated_metric.value} exceeds 1.0 for ratio metric {self.metric_id} which has zero_to_one set to true.")
+                    numerator_value = self.aggregated_metric.value * denominator_value
+                    diff = denominator_value - numerator_value
+                    self.belief = BetaBelief(alpha=1.0 + numerator_value, beta=1.0 + diff)
+                    logger.debug(f"Beta belief: {self.belief}")
+                    return
+                else:  # Gaussian or constant or undefined
+                    mm = ratio_max_mins[self.metric_id]
+                    logger.debug(f"Ratio max mins: {mm}")
+                    if mm.maximum is not None and mm.minimum is not None:
+                        width = mm.maximum - mm.minimum
+                        if width > 0: # gaussian
+                            self.belief = GaussianBelief(mean= self.aggregated_metric.value, variance=width*AdvancedParameters.variance_boost_factor / (1 + denominator_value))
+                            logger.debug(f"Gaussian belief: {self.belief}")
                             return
-                    else: # try to use Gaussian belief
-                        mm = ratio_max_mins[self.metric_id]
-                        logger.debug(f"Ratio max mins: {mm}")
-                        if mm.maximum is not None and mm.minimum is not None:
-                            width = mm.maximum - mm.minimum
-                            if width > 0:
-                                self.belief = GaussianBelief(mean = self.aggregated_metric.value, variance=width*AdvancedParameters.variance_boost_factor / (1 + denominator_value))
-                                logger.debug(f"Gaussian belief: {self.belief}")
-                                return
-                            else:
-                                self.belief = ConstantBelief(value = mm.maximum)
-                                logger.debug(f"Constant belief: {self.belief}")
-                                return
+                        else: # use constant belief.
+                            self.belief = ConstantBelief(value= mm.maximum)
+                            logger.debug(f"Constant belief: {self.belief}")
+                            return
+                    # else undefined belief

--- a/iter8_analytics/api/analytics/detailedversion.py
+++ b/iter8_analytics/api/analytics/detailedversion.py
@@ -107,7 +107,7 @@ class DetailedVersion():
         """
         for rm in self.metrics["ratio_metrics"].values():
             rm.update_belief()
-            logger.info(f"Updated belief: {vars(rm.belief)}")
+            logger.debug(f"Updated belief: {vars(rm.belief)}")
 
     def create_ratio_metric_samples(self):
         """Create ratio metric samples used for assessment and traffic routing

--- a/iter8_analytics/api/analytics/detailedversion.py
+++ b/iter8_analytics/api/analytics/detailedversion.py
@@ -85,10 +85,17 @@ class DetailedVersion():
             new_counter_metrics (Dict[iter8id, CounterDataPoint]): dictionary mapping from metric id to CounterDataPoint
         """
         for metric_id in new_counter_metrics:
-            if new_counter_metrics[metric_id].value is not None:
-                self.metrics["counter_metrics"][metric_id].set_aggregated_metric(AggregatedCounterDataPoint(
-                    ** new_counter_metrics[metric_id].dict()
-                ))
+            logger.debug(f"Aggregated counter metric before. Version: {self.id} Metric: {metric_id} Aggregated Counter Metric: {self.metrics['counter_metrics'][metric_id].aggregated_metric}")
+
+            old_val = self.metrics['counter_metrics'][metric_id].aggregated_metric.value
+            new_val = new_counter_metrics[metric_id].value
+            if new_val is not None:
+                if old_val is not None and old_val > new_val:
+                    break # counters should only increase. new_val is zero
+                    
+                self.metrics["counter_metrics"][metric_id].set_aggregated_metric(AggregatedCounterDataPoint(** new_counter_metrics[metric_id].dict()))
+
+            logger.debug(f"Aggregated counter metric after. Version: {self.id} Metric: {metric_id} Aggregated Counter Metric: {self.metrics['counter_metrics'][metric_id].aggregated_metric}")
         
     def aggregate_ratio_metrics(self, new_ratio_metrics: Dict[iter8id, RatioDataPoint]):
         """combine aggregated ratio metrics from last state for this version with new ratio metrics. Aggregated results stored in self.aggregated_ratio_metrics
@@ -97,15 +104,30 @@ class DetailedVersion():
             new_ratio_metrics (Dict[iter8id, RatioDataPoint]): dictionary mapping from metric id to RatioDataPoint
         """
         for metric_id in new_ratio_metrics:
+            logger.debug(f"Aggregated ratio metric before. Version: {self.id} Metric: {metric_id} Aggregated Ratio Metric: {self.metrics['ratio_metrics'][metric_id].aggregated_metric}")
+
             if new_ratio_metrics[metric_id].value is not None:
+                logger.debug(f"New Ratio metric. Version: {self.id} Metric: {metric_id} New Ratio Metric: {new_ratio_metrics[metric_id]}")
+
+                # prefer all_ok to zeroed_ratio
+                if new_ratio_metrics[metric_id].status == StatusEnum.zeroed_ratio:
+                    if self.metrics['ratio_metrics'][metric_id].aggregated_metric.status == StatusEnum.all_ok:
+                        break
+
+                # otherwise, go ahead and update
                 self.metrics["ratio_metrics"][metric_id].set_aggregated_metric(AggregatedRatioDataPoint(
                     ** new_ratio_metrics[metric_id].dict()
                 ))
-                
+
+            logger.debug(f"Aggregated ratio metric after. Version: {self.id} Metric: {metric_id} Aggregated Ratio Metric: {self.metrics['ratio_metrics'][metric_id].aggregated_metric}")
+
+
     def update_beliefs(self):
         """Update beliefs for ratio metrics. If belief update is not possible due to insufficient data, then the relevant status codes are populated here
         """
         for rm in self.metrics["ratio_metrics"].values():
+            logger.debug(f"Version: {self.id} Metric: {rm.metric_id}")
+            logger.debug(f"detailed metric: {rm.aggregated_metric}")
             rm.update_belief()
             logger.debug(f"Updated belief: {vars(rm.belief)}")
 
@@ -134,8 +156,11 @@ class DetailedVersion():
 
     def get_criteria_mask(self):
         product_cm = np.ones((Belief.sample_size, ))
+        logger.debug(f"Creating criteria mask for version: {self.id}")
         for criterion in self.experiment.eip.criteria:
             cm = self.detailed_criteria[criterion.id].get_criterion_mask()
+            logger.debug(f"Criteria with metric {criterion.metric_id}")
+            logger.debug(cm)
             product_cm *= cm
         return product_cm
             

--- a/iter8_analytics/api/analytics/endpoints/examples.py
+++ b/iter8_analytics/api/analytics/endpoints/examples.py
@@ -439,83 +439,71 @@ eip_with_unknown_metric_in_criterion["criteria"].append({
 })
 
 
-eip_with_current_time = {
+eip_with_percentile = {
     "name": "productpage-abn-test",
     "start_time": "2020-07-17T20:05:02-04:00",
     "service_name": "productpage",
-    "iteration_number": 0,
+    "iteration_number": 1,
     "metric_specs": {
         "counter_metrics": [{
             "name": "iter8_request_count",
-            "preferred_direction": "lower",
-            "query_template": "sum(increase(istio_requests_total{reporter='source',job='istio-mesh'}[$interval])) by ($version_labels)"
+            "query_template": "sum(increase(istio_requests_total{reporter='source'}[$interval])) by ($version_labels)"
         }, {
             "name": "iter8_total_latency",
-            "preferred_direction": "lower",
-            "query_template": "(sum(increase(istio_request_duration_milliseconds_sum{reporter='source',job='istio-mesh'}[$interval])) by ($version_labels))*1000"
+            "query_template": "(sum(increase(istio_request_duration_milliseconds_sum{reporter='source'}[$interval])) by ($version_labels))"
         }, {
             "name": "iter8_error_count",
-            "preferred_direction": "higher",
-            "query_template": "sum(increase(istio_requests_total{response_code=~'5..',reporter='source',job='istio-mesh'}[$interval])) by ($version_labels)"
+            "preferred_direction": "lower",
+            "query_template": "sum(increase(istio_requests_total{response_code=~'5..',reporter='source'}[$interval])) by ($version_labels)"
         }, {
             "name": "books_purchased_total",
             "preferred_direction": "higher",
             "query_template": "sum(increase(number_of_books_purchased_total{}[$interval])) by ($version_labels)"
         }, {
-            "name": "500_ms_latency_percentile",
+            "name": "500_ms_latency_count",
             "preferred_direction": "higher",
-            "query_template": "(sum(increase(istio_request_duration_milliseconds_bucket{le='500',reporter='source',job='istio-mesh'}[$interval])) by ($version_labels))"
-        }, {
-            "name": "latency_percentile_total",
-            "query_template": "(sum(increase(istio_request_duration_milliseconds_bucket{le='10000',reporter='source',job='istio-mesh'}[$interval])) by ($version_labels))"
+            "query_template": "(sum(increase(istio_request_duration_milliseconds_bucket{le='500',reporter='source'}[$interval])) by ($version_labels))"
         }],
         "ratio_metrics": [{
             "name": "iter8_mean_latency",
             "numerator": "iter8_total_latency",
-            "denominator": "iter8_request_count"
+            "denominator": "iter8_request_count",
+            "preferred_direction": "lower"
         }, {
             "name": "iter8_error_rate",
             "numerator": "iter8_error_count",
             "denominator": "iter8_request_count",
+            "preferred_direction": "lower",
             "zero_to_one": True
         }, {
             "name": "mean_books_purchased",
             "numerator": "books_purchased_total",
-            "denominator": "iter8_request_count"
+            "denominator": "iter8_request_count",
+            "preferred_direction": "higher"
         }, {
-            "name": "mean_500_ms_latency_percentile",
-            "numerator": "500_ms_latency_percentile",
-            "denominator": "latency_percentile_total"
+            "name": "500_ms_latency_percentile",
+            "numerator": "500_ms_latency_count",
+            "denominator": "iter8_request_count",
+            "preferred_direction": "higher",
+            "zero_to_one": True
         }]
     },
     "criteria": [{
-        "id": "iter8_mean_latency",
-        "metric_id": "iter8_mean_latency",
-        "is_reward": False,
-        "threshold": {
-            "threshold_type": "relative",
-            "value": 0.6
-        }
-    }, {
-        "id": "iter8_error_rate",
-        "metric_id": "iter8_error_rate",
-        "is_reward": False,
-        "threshold": {
-            "threshold_type": "absolute",
-            "value": 0.05
-        }
-    }, {
-        "id": "mean_500_ms_latency_percentile",
-        "metric_id": "mean_500_ms_latency_percentile",
+        "id": "0",
+        "metric_id": "500_ms_latency_percentile",
         "is_reward": False,
         "threshold": {
             "threshold_type": "absolute",
             "value": 0.99
         }
     }, {
-        "id": "mean_books_purchased",
-        "metric_id": "mean_books_purchased",
-        "is_reward": True
+        "id": "1",
+        "metric_id": "iter8_error_rate",
+        "is_reward": False,
+        "threshold": {
+            "threshold_type": "absolute",
+            "value": 0.0001
+        }
     }],
     "baseline": {
         "id": "productpage-v1",

--- a/iter8_analytics/api/analytics/endpoints/examples.py
+++ b/iter8_analytics/api/analytics/endpoints/examples.py
@@ -536,3 +536,276 @@ reviews_example_without_request_count = copy.deepcopy(reviews_example)
 del reviews_example_without_request_count["criteria"][1]
 del reviews_example_without_request_count["metric_specs"]["counter_metrics"][0]
 del reviews_example_without_request_count["metric_specs"]["ratio_metrics"][0]
+
+eip_with_assessment = {
+    "name": "productpage-abn-test",
+    "start_time": "2020-07-20T17:19:13-04:00",
+    "service_name": "productpage",
+    "iteration_number": 17,
+    "metric_specs": {
+        "counter_metrics": [{
+            "name": "iter8_request_count",
+            "query_template": "sum(increase(istio_requests_total{reporter='source',job='istio-mesh'}[$interval])) by ($version_labels)"
+        }, {
+            "name": "iter8_total_latency",
+            "query_template": "(sum(increase(istio_request_duration_seconds_sum{reporter='source',job='istio-mesh'}[$interval])) by ($version_labels))*1000"
+        }, {
+            "name": "iter8_error_count",
+            "preferred_direction": "lower",
+            "query_template": "sum(increase(istio_requests_total{response_code=~'5..',reporter='source',job='istio-mesh'}[$interval])) by ($version_labels)"
+        }, {
+            "name": "books_purchased_total",
+            "query_template": "sum(increase(number_of_books_purchased_total{}[$interval])) by ($version_labels)"
+        }, {
+            "name": "le_500_ms_latency_request_count",
+            "query_template": "(sum(increase(istio_request_duration_seconds_bucket{le='0.5',reporter='source',job='istio-mesh'}[$interval])) by ($version_labels))"
+        }],
+        "ratio_metrics": [{
+            "name": "iter8_mean_latency",
+            "numerator": "iter8_total_latency",
+            "denominator": "iter8_request_count",
+            "preferred_direction": "lower"
+        }, {
+            "name": "iter8_error_rate",
+            "numerator": "iter8_error_count",
+            "denominator": "iter8_request_count",
+            "zero_to_one": True,
+            "preferred_direction": "lower"
+        }, {
+            "name": "mean_books_purchased",
+            "numerator": "books_purchased_total",
+            "denominator": "iter8_request_count",
+            "preferred_direction": "higher"
+        }, {
+            "name": "500_ms_latency_percentile",
+            "numerator": "le_500_ms_latency_request_count",
+            "denominator": "iter8_request_count",
+            "zero_to_one": True,
+            "preferred_direction": "higher"
+        }]
+    },
+    "criteria": [{
+        "id": "iter8_mean_latency",
+        "metric_id": "iter8_mean_latency",
+        "is_reward": False,
+        "threshold": {
+            "threshold_type": "absolute",
+            "value": 1500
+        }
+    }, {
+        "id": "iter8_error_rate",
+        "metric_id": "iter8_error_rate",
+        "is_reward": False,
+        "threshold": {
+            "threshold_type": "absolute",
+            "value": 0.05
+        }
+    }, {
+        "id": "500_ms_latency_percentile",
+        "metric_id": "500_ms_latency_percentile",
+        "is_reward": False,
+        "threshold": {
+            "threshold_type": "absolute",
+            "value": 0.9
+        }
+    }, {
+        "id": "mean_books_purchased",
+        "metric_id": "mean_books_purchased",
+        "is_reward": True
+    }],
+    "baseline": {
+        "id": "productpage-v1",
+        "version_labels": {
+            "destination_workload": "productpage-v1",
+            "destination_workload_namespace": "kubecon-demo"
+        }
+    },
+    "candidates": [{
+        "id": "productpage-v2",
+        "version_labels": {
+            "destination_workload": "productpage-v2",
+            "destination_workload_namespace": "kubecon-demo"
+        }
+    }, {
+        "id": "productpage-v3",
+        "version_labels": {
+            "destination_workload": "productpage-v3",
+            "destination_workload_namespace": "kubecon-demo"
+        }
+    }],
+    "last_state": {
+        "aggregated_counter_metrics": {
+            "productpage-v1": {
+                "books_purchased_total": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.001436+00:00",
+                    "value": 2675.060869565217
+                },
+                "iter8_error_count": {
+                    "status": "no versions in prometheus response",
+                    "timestamp": "2020-07-20T21:25:00.726973+00:00",
+                    "value": 0
+                },
+                "iter8_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.500394+00:00",
+                    "value": 1100.9376796274955
+                },
+                "iter8_total_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.608216+00:00",
+                    "value": 116867.79877397961
+                },
+                "le_500_ms_latency_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.880245+00:00",
+                    "value": 1066.2376477633036
+                }
+            },
+            "productpage-v2": {
+                "books_purchased_total": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.001436+00:00",
+                    "value": 43495.340441392604
+                },
+                "iter8_error_count": {
+                    "status": "no versions in prometheus response",
+                    "timestamp": "2020-07-20T21:25:00.726973+00:00",
+                    "value": 0
+                },
+                "iter8_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.500394+00:00",
+                    "value": 1103.040681252753
+                },
+                "iter8_total_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.608216+00:00",
+                    "value": 1513982.9278989176
+                },
+                "le_500_ms_latency_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.880245+00:00",
+                    "value": 270.2396902763801
+                }
+            },
+            "productpage-v3": {
+                "books_purchased_total": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.001436+00:00",
+                    "value": 15931.255805285438
+                },
+                "iter8_error_count": {
+                    "status": "no versions in prometheus response",
+                    "timestamp": "2020-07-20T21:25:00.726973+00:00",
+                    "value": 0
+                },
+                "iter8_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.500394+00:00",
+                    "value": 1084.1133447970965
+                },
+                "iter8_total_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.608216+00:00",
+                    "value": 98910.32374279092
+                },
+                "le_500_ms_latency_request_count": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:00.880245+00:00",
+                    "value": 1074.6497084334599
+                }
+            }
+        },
+        "aggregated_ratio_metrics": {
+            "productpage-v1": {
+                "500_ms_latency_percentile": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.488586+00:00",
+                    "value": 0.9684813840907572
+                },
+                "iter8_error_rate": {
+                    "status": "zeroed ratio",
+                    "timestamp": "2020-07-20T21:25:01.342217+00:00",
+                    "value": 0
+                },
+                "iter8_mean_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.118267+00:00",
+                    "value": 106.15296481951826
+                },
+                "mean_books_purchased": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.617785+00:00",
+                    "value": 2.422820076378882
+                }
+            },
+            "productpage-v2": {
+                "500_ms_latency_percentile": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.488586+00:00",
+                    "value": 0.24499521628654852
+                },
+                "iter8_error_rate": {
+                    "status": "zeroed ratio",
+                    "timestamp": "2020-07-20T21:25:01.342217+00:00",
+                    "value": 0
+                },
+                "iter8_mean_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.118267+00:00",
+                    "value": 1372.5540260033258
+                },
+                "mean_books_purchased": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.617785+00:00",
+                    "value": 39.38968647171404
+                }
+            },
+            "productpage-v3": {
+                "500_ms_latency_percentile": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.488586+00:00",
+                    "value": 0.9912706209096545
+                },
+                "iter8_error_rate": {
+                    "status": "zeroed ratio",
+                    "timestamp": "2020-07-20T21:25:01.342217+00:00",
+                    "value": 0
+                },
+                "iter8_mean_latency": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.118267+00:00",
+                    "value": 91.23614631023943
+                },
+                "mean_books_purchased": {
+                    "status": "all_ok",
+                    "timestamp": "2020-07-20T21:25:01.617785+00:00",
+                    "value": 14.679574964516965
+                }
+            }
+        },
+        "ratio_max_mins": {
+            "500_ms_latency_percentile": {
+                "maximum": 0.9912706209096545,
+                "minimum": 0.16666650018723458
+            },
+            "iter8_error_rate": {
+                "maximum": 0,
+                "minimum": 0
+            },
+            "iter8_mean_latency": {
+                "maximum": 1507.8847318570406,
+                "minimum": 91.23614631023943
+            },
+            "mean_books_purchased": {
+                "maximum": 39.693079869958254,
+                "minimum": 2.2894643119744784
+            }
+        }
+    }, 
+    "traffic_control": {
+        "max_increment": 25,
+        "strategy": "progressive"
+    }
+}

--- a/iter8_analytics/api/analytics/experiment.py
+++ b/iter8_analytics/api/analytics/experiment.py
@@ -167,10 +167,20 @@ class Experiment():
             # this step involves creating detailed criteria, along with reward and criterion masks
             detailed_version.create_criteria_assessments()
             # reward and criteria masks are used to compute utility samples
-            self.rewards[detailed_version.id] = detailed_version.get_reward_sample()
+            self.rewards[detailed_version.id] = detailed_version.get_reward_sample()            
             self.criteria_mask[detailed_version.id] = detailed_version.get_criteria_mask()
         # utility samples are needed for winner assessment and traffic recommendations
+        logger.debug("Reward sample")
+        logger.debug(self.rewards.head())
+
+        logger.debug("Criteria mask")
+        logger.debug(self.criteria_mask.head())
+
         self.create_utility_samples()
+
+        logger.debug("Utility sample")
+        logger.debug(self.utilities.head())
+
         self.create_winner_assessments()
         # self.add_baseline_bias()
         self.create_traffic_recommendations()

--- a/iter8_analytics/api/analytics/experiment.py
+++ b/iter8_analytics/api/analytics/experiment.py
@@ -160,7 +160,7 @@ class Experiment():
 
         for detailed_version in self.detailed_versions.values():
             # beliefs are needed for creating posterior samples
-            logger.info(f"Updating beliefs for {detailed_version.id}")
+            logger.debug(f"Updating beliefs for {detailed_version.id}")
             detailed_version.update_beliefs()
             # posterior samples for ratio metrics are needed to create reward and criterion masks
             detailed_version.create_ratio_metric_samples()
@@ -296,7 +296,7 @@ class Experiment():
         """
         self.traffic_split[k] = {}
 
-        logger.info(f"Top k split with k = {k}")
+        logger.debug(f"Top k split with k = {k}")
 
         logger.debug("Utilities")
         logger.debug(self.utilities.head())

--- a/iter8_analytics/api/analytics/metrics.py
+++ b/iter8_analytics/api/analytics/metrics.py
@@ -198,7 +198,7 @@ class PrometheusMetricQuery():
         """
         interval = int((current_time - self.query_spec.start_time).total_seconds())
         if interval < 20.0: # less than twenty seconds has elapsed since start of the experiment
-            logger.info("Less than 20 seconds have elapsed since the start of the experiment")
+            logger.debug("Less than 20 seconds have elapsed since the start of the experiment")
             return self.post_process({
                 "status": "success", 
                 "data": {

--- a/iter8_analytics/api/analytics/types.py
+++ b/iter8_analytics/api/analytics/types.py
@@ -255,4 +255,4 @@ class AdvancedParameters:
     exploration_traffic_percentage = 5.0 # 5% of traffic always used for exploration
     posterior_probability_for_credible_intervals = 0.95
     min_posterior_probability_for_winner = 0.99 # no winner until iter8 is 99% confident
-    variance_boost_factor = 100.0 # a higher value of this factor encourages greater exploration
+    variance_boost_factor = 1.0 # a higher value of this factor encourages greater exploration

--- a/iter8_analytics/fastapi_app.py
+++ b/iter8_analytics/fastapi_app.py
@@ -72,7 +72,7 @@ def config_logger(log_level = "debug"):
             ' - %(filename)s:%(lineno)d - %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logging.getLogger('iter8_analytics').info("Configured logger")
+    logging.getLogger('iter8_analytics').debug("Configured logger")
 
 if __name__ == '__main__':
     config_logger(config.env_config[constants.LOG_LEVEL])

--- a/tests/api/analytics/endpoints/detailedmetric_test.py
+++ b/tests/api/analytics/endpoints/detailedmetric_test.py
@@ -1,0 +1,86 @@
+"""Tests for module iter8_analytics.api.analytics.endpoints.metrics"""
+# standard python stuff
+import logging
+import requests_mock
+import json
+
+# iter8 stuff
+from iter8_analytics import fastapi_app
+from iter8_analytics.api.analytics.types import *
+import iter8_analytics.constants as constants
+import iter8_analytics.config as config
+from iter8_analytics.api.analytics.detailedmetric import *
+from iter8_analytics.api.analytics.endpoints.examples import *
+from iter8_analytics.api.analytics.detailedversion import *
+from iter8_analytics.api.analytics.experiment import *
+
+env_config = config.get_env_config()
+fastapi_app.config_logger(env_config[constants.LOG_LEVEL])
+logger = logging.getLogger('iter8_analytics')
+
+metrics_backend_url = env_config[constants.METRICS_BACKEND_CONFIG_URL]
+metrics_endpoint = f'{metrics_backend_url}/api/v1/query'
+
+class TestDetailedMetrics:
+    def test_non_zero_to_one_belief_update(self):
+        eip = ExperimentIterationParameters(** eip_with_percentile)
+        exp = Experiment(eip)
+        dv = DetailedCandidateVersion(eip.candidates[0], exp, 2.0)
+        rm = DetailedRatioMetric(eip.metric_specs.ratio_metrics[0], dv)
+
+        exp.ratio_max_mins = {
+            rm.metric_id: RatioMaxMin(minimum = 5.7, maximum = 8.9)
+        }
+
+        rm.aggregated_metric = AggregatedRatioDataPoint(value = 6.2, timestamp = datetime.now(timezone.utc))
+
+        denominator_id = rm.metric_spec.denominator
+        rm.detailed_version.metrics["counter_metrics"][denominator_id] = DetailedCounterMetric(eip.metric_specs.ratio_metrics[0], dv)
+        rm.detailed_version.metrics["counter_metrics"][denominator_id].aggregated_metric = AggregatedCounterDataPoint(value = 6.3, timestamp = datetime.now(timezone.utc))
+        rm.update_belief()
+
+    def test_bad_zero_to_one_belief_update(self):
+        bad_eip = copy.deepcopy(eip_with_percentile)
+        bad_eip["metric_specs"]["ratio_metrics"][0]["zero_to_one"] = True
+
+        eip = ExperimentIterationParameters(** bad_eip)
+
+        exp = Experiment(eip)
+        dv = DetailedCandidateVersion(eip.candidates[0], exp, 2.0)
+        rm = DetailedRatioMetric(eip.metric_specs.ratio_metrics[0], dv)
+
+        exp.ratio_max_mins = {
+            rm.metric_id: RatioMaxMin(minimum = 5.7, maximum = 8.9)
+        }
+
+        rm.aggregated_metric = AggregatedRatioDataPoint(value = 6.2, timestamp = datetime.now(timezone.utc))
+
+        denominator_id = rm.metric_spec.denominator
+        rm.detailed_version.metrics["counter_metrics"][denominator_id] = DetailedCounterMetric(eip.metric_specs.ratio_metrics[0], dv)
+        rm.detailed_version.metrics["counter_metrics"][denominator_id].aggregated_metric = AggregatedCounterDataPoint(value = 6.3, timestamp = datetime.now(timezone.utc))
+
+        try:
+            rm.update_belief()
+        except HTTPException as e:
+            pass
+
+    def test_good_zero_to_one_belief_update(self):
+        eip = ExperimentIterationParameters(** eip_with_percentile)
+
+        exp = Experiment(eip)
+        dv = DetailedCandidateVersion(eip.candidates[0], exp, 2.0)
+        rm = DetailedRatioMetric(eip.metric_specs.ratio_metrics[3], dv)
+
+        exp.ratio_max_mins = {
+            rm.metric_id: RatioMaxMin(minimum = 0.3, maximum = 1.0)
+        }
+
+        rm.aggregated_metric = AggregatedRatioDataPoint(value = 0.993, timestamp = datetime.now(timezone.utc))
+
+        denominator_id = rm.metric_spec.denominator
+        rm.detailed_version.metrics["counter_metrics"][denominator_id] = DetailedCounterMetric(eip.metric_specs.ratio_metrics[0], dv)
+        rm.detailed_version.metrics["counter_metrics"][denominator_id].aggregated_metric = AggregatedCounterDataPoint(value = 13, timestamp = datetime.now(timezone.utc))
+
+        rm.update_belief()
+
+

--- a/tests/api/analytics/endpoints/experiment_test.py
+++ b/tests/api/analytics/endpoints/experiment_test.py
@@ -144,7 +144,7 @@ class TestExperiment:
         with requests_mock.mock(real_http=True) as m:
             m.get(metrics_endpoint, json=json.load(open("tests/data/prometheus_sample_response.json")))
 
-            eip = ExperimentIterationParameters(** eip_with_current_time)
+            eip = ExperimentIterationParameters(** eip_with_percentile)
             eip.start_time = datetime.now(timezone.utc)
             exp = Experiment(eip)
             exp.run()

--- a/tests/api/analytics/endpoints/experiment_test.py
+++ b/tests/api/analytics/endpoints/experiment_test.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import datetime,timezone
 import json
+from pprint import pformat
 
 # python libraries
 import requests_mock
@@ -170,3 +171,13 @@ class TestDetailedVersion:
         })
 
         exp_with_partial_last_state.detailed_versions['reviews_candidate'].create_criteria_assessments()
+
+class TestAssessments:
+    def test_assessment(self):
+        with requests_mock.mock(real_http=True) as m:
+            m.get(metrics_endpoint, json=json.load(open("tests/data/prometheus_no_data_response.json")))
+
+            eip = ExperimentIterationParameters(** eip_with_assessment)
+            exp = Experiment(eip)
+            res = exp.run()
+

--- a/tests/api/analytics/endpoints/metrics_test.py
+++ b/tests/api/analytics/endpoints/metrics_test.py
@@ -338,4 +338,3 @@ class TestMetrics:
         assert nrmm["metric1"] == RatioMaxMin(minimum = 0.1, maximum = 0.3)
         assert nrmm["metric2"] == RatioMaxMin(minimum = 0.2, maximum = 0.2)
         assert nrmm["metric3"] == RatioMaxMin()
-


### PR DESCRIPTION
This resolves the time sync issue which @kalantar brought up.

In all other respects, it will behave the same as we as before for zero_to_one ratio metrics.